### PR TITLE
Check IP blocklists for spammy-looking requests

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,4 +5,4 @@ v1.0.0, 2021-02-23 -- Insist on being passed a request session instead of using 
 v1.2.0, 2021-04-11 -- Add optional site restricted search
 v1.2.1, 2022-06-23 -- Block results pages from being indexed; block bots from using search API
 v1.2.2, 2022-07-06 -- Block searches with weird characters in them
-v1.2.3, 2022-07-08 -- Check IP blacklists for spammy-looking requests
+v1.2.3, 2022-07-08 -- Check IP blocklists for spammy-looking requests

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,3 +5,4 @@ v1.0.0, 2021-02-23 -- Insist on being passed a request session instead of using 
 v1.2.0, 2021-04-11 -- Add optional site restricted search
 v1.2.1, 2022-06-23 -- Block results pages from being indexed; block bots from using search API
 v1.2.2, 2022-07-06 -- Block searches with weird characters in them
+v1.2.3, 2022-07-08 -- Check IP blacklists for spammy-looking requests

--- a/canonicalwebteam/search/views.py
+++ b/canonicalwebteam/search/views.py
@@ -68,13 +68,13 @@ def build_search_view(
             if any(char in query for char in illegal_characters):
                 flask.abort(403, "Search query contains an illegal character")
 
-            # Block spammers from blacklists
+            # Block spammers from blocklists
             if ".com" in query:
                 ipcheck = DNSBLIpChecker().check(flask.request.remote_addr)
                 if ipcheck.blacklisted:
-                    blacklists = ", ".join(ipcheck.detected_by.keys())
+                    blocklists = ", ".join(ipcheck.detected_by.keys())
                     flask.abort(
-                        403, f"IP address detected in blacklists: {blacklists}"
+                        403, f"IP address detected in blocklists: {blocklists}"
                     )
 
             # Block if a search bot

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,6 @@ setup(
     packages=find_packages(),
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
-    install_requires=["Flask>=1.0.2", "user-agents>=2.0.0"],
+    install_requires=["Flask>=1.0.2", "user-agents>=2.0.0", "pydnsbl>=1.1.4"],
     tests_require=["httpretty"],
 )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.search",
-    version="1.2.2",
+    version="1.2.3",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical-web-and-design/canonicalwebteam.search",


### PR DESCRIPTION
- If a query has ".com" in it, check the IP blocklists
- v1.2.3: Check IP blocklists for spammy-looking requests

QA
--

Send [spammy request](https://logging.comms.canonical.com/search?rangetype=relative&fields=message%2Csource&width=1920&highlightMessage=&relative=300&q=querystring%3A+q%3D*+AND+path%3A+%5C%2Fserver%5C%2Fdocs%5C%2Fsearch) from non-blocked IP, takes longer but doesn't block (200 status):

```
curl -I "https://ubuntu-com-11811.demos.haus/search?q=kvts.jingpindyy.com_"
```

Send spammy request from spammy IP, blocks (403 result):

```
curl -H "X-Forwarded-For: 43.239.85.160" -I "https://ubuntu-com-11811.demos.haus/search?q=kvts.jingpindyy.com_"
```