### PR TITLE
Remove blocklist checks; move blocking logic to core search function

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,3 +6,5 @@ v1.2.0, 2021-04-11 -- Add optional site restricted search
 v1.2.1, 2022-06-23 -- Block results pages from being indexed; block bots from using search API
 v1.2.2, 2022-07-06 -- Block searches with weird characters in them
 v1.2.3, 2022-07-08 -- Check IP blocklists for spammy-looking requests
+v1.2.4, 2022-07-09 -- Remove blocklist checks; move blocking logic to core search function
+

--- a/canonicalwebteam/search/models.py
+++ b/canonicalwebteam/search/models.py
@@ -25,10 +25,18 @@ def get_search_results(
     if any(char in query for char in illegal_characters):
         flask.abort(403, "Search query contains an illegal character")
 
-    # Block if a search bot
-    agent = user_agents.parse(str(flask.request.user_agent))
-    if agent.is_bot:
-        flask.abort(403, "Search engine crawlers can't perform searches")
+    # Block web crawlers
+    bot_prefixes = (
+        "python-requests",
+        "curl",
+        "urlwatch",
+        "GuzzleHttp",
+        "Feedly",
+    )
+    ua_string = str(flask.request.user_agent)
+    agent = user_agents.parse(ua_string)
+    if agent.is_bot or ua_string.startswith(bot_prefixes):
+        flask.abort(403, "Web crawlers may not perform searches")
 
     url_endpoint = "https://www.googleapis.com/customsearch/v1"
 

--- a/canonicalwebteam/search/models.py
+++ b/canonicalwebteam/search/models.py
@@ -1,4 +1,9 @@
-def get_search_results(  # noqa: E302
+# Packages
+import flask
+import user_agents
+
+
+def get_search_results(
     session,
     api_key,
     query,
@@ -13,6 +18,18 @@ def get_search_results(  # noqa: E302
 
     https://developers.google.com/custom-search/v1/site_restricted_api
     """
+
+    # Block weird characters
+    illegal_characters = ("【", "】")
+
+    if any(char in query for char in illegal_characters):
+        flask.abort(403, "Search query contains an illegal character")
+
+    # Block if a search bot
+    agent = user_agents.parse(str(flask.request.user_agent))
+    if agent.is_bot:
+        flask.abort(403, "Search engine crawlers can't perform searches")
+
     url_endpoint = "https://www.googleapis.com/customsearch/v1"
 
     if site_restricted_search:

--- a/canonicalwebteam/search/models.py
+++ b/canonicalwebteam/search/models.py
@@ -33,9 +33,13 @@ def get_search_results(
         "GuzzleHttp",
         "Feedly",
     )
-    ua_string = str(flask.request.user_agent)
-    agent = user_agents.parse(ua_string)
-    if agent.is_bot or ua_string.startswith(bot_prefixes):
+    bot_contains = ("HeadlessChrome", "Assetnote")
+    agent = user_agents.parse(str(flask.request.user_agent))
+    if (
+        agent.is_bot
+        or agent.ua_string.startswith(bot_prefixes)
+        or any(substr in agent.ua_string for substr in bot_contains)
+    ):
         flask.abort(403, "Web crawlers may not perform searches")
 
     url_endpoint = "https://www.googleapis.com/customsearch/v1"

--- a/canonicalwebteam/search/views.py
+++ b/canonicalwebteam/search/views.py
@@ -3,8 +3,6 @@ import os
 
 # Packages
 import flask
-import user_agents
-from pydnsbl import DNSBLIpChecker
 
 # Local
 from canonicalwebteam.search.models import get_search_results
@@ -62,28 +60,6 @@ def build_search_view(
         results = None
 
         if query:
-            # Block weird characters
-            illegal_characters = ("【", "】")
-
-            if any(char in query for char in illegal_characters):
-                flask.abort(403, "Search query contains an illegal character")
-
-            # Block spammers from blocklists
-            if ".com" in query:
-                ipcheck = DNSBLIpChecker().check(flask.request.remote_addr)
-                if ipcheck.blacklisted:
-                    blocklists = ", ".join(ipcheck.detected_by.keys())
-                    flask.abort(
-                        403, f"IP address detected in blocklists: {blocklists}"
-                    )
-
-            # Block if a search bot
-            agent = user_agents.parse(str(flask.request.user_agent))
-            if agent.is_bot:
-                flask.abort(
-                    403, "Search engine crawlers can't perform searches"
-                )
-
             results = get_search_results(
                 session=session,
                 api_key=search_api_key,

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,6 @@ setup(
     packages=find_packages(),
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
-    install_requires=["Flask>=1.0.2", "user-agents>=2.0.0", "pydnsbl>=1.1.4"],
+    install_requires=["Flask>=1.0.2", "user-agents>=2.0.0"],
     tests_require=["httpretty"],
 )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.search",
-    version="1.2.3",
+    version="1.2.4",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical-web-and-design/canonicalwebteam.search",


### PR DESCRIPTION
The blocking logic should of course be in the `get_search_results` function, so that it applies to e.g. tutorials search, which doesn't use the `build_search_view`.

Remove blocklist logic, because it was actually catching basically all IPs, making it pretty useless.

Block useragent strings from known crawler software - "curl", "python-requests", ""urlwatch", "GuzzleHttp", "Feedly"

Fixes https://github.com/canonical/Web-design-systems-squad/issues/15

QA
--

Do some searches on this demo https://ubuntu-com-11811.demos.haus/.
