### PR TITLE
block more scripts

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,4 +7,5 @@ v1.2.1, 2022-06-23 -- Block results pages from being indexed; block bots from us
 v1.2.2, 2022-07-06 -- Block searches with weird characters in them
 v1.2.3, 2022-07-08 -- Check IP blocklists for spammy-looking requests
 v1.2.4, 2022-07-09 -- Remove blocklist checks; move blocking logic to core search function
+v1.2.5, 2022-07-12 -- Block some more bot useragents
 

--- a/canonicalwebteam/search/models.py
+++ b/canonicalwebteam/search/models.py
@@ -27,13 +27,23 @@ def get_search_results(
 
     # Block web crawlers
     bot_prefixes = (
-        "python-requests",
+        "python",  # python-requests/, python-urllib3/, Python/ etc.
+        "Go-http-client",
+        "kube-probe",
+        "Prometheus",
         "curl",
         "urlwatch",
         "GuzzleHttp",
         "Feedly",
+        "github-camo",
+        "Site24x7",
+        "check_http",
+        "Tiny Tiny RSS",
+        "RSS Discovery Engine",
+        "NetNewsWire",
+        "ALittle Client",
     )
-    bot_contains = ("HeadlessChrome", "Assetnote")
+    bot_contains = ("HeadlessChrome/", "Assetnote/")
     agent = user_agents.parse(str(flask.request.user_agent))
     if (
         agent.is_bot

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.search",
-    version="1.2.4",
+    version="1.2.5",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical-web-and-design/canonicalwebteam.search",


### PR DESCRIPTION
I went through the logs and found a few more useragents that are clearly bots that we aren't blocking. Not hugely impactful, but it should be helpful.