### PR TITLE
Block search spammers

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,3 +9,4 @@ v1.2.3, 2022-07-08 -- Check IP blocklists for spammy-looking requests
 v1.2.4, 2022-07-09 -- Remove blocklist checks; move blocking logic to core search function
 v1.2.5, 2022-07-12 -- Block some more bot useragents
 v1.2.6, 2022-07-13 -- Block one more useragent - "gh"
+v1.2.7, 2022-07-15 -- Block more user agents - "Petalbot"

--- a/canonicalwebteam/search/models.py
+++ b/canonicalwebteam/search/models.py
@@ -44,7 +44,7 @@ def get_search_results(
         "ALittle Client",
         "gh",
     )
-    bot_contains = ("HeadlessChrome/", "Assetnote/")
+    bot_contains = ("HeadlessChrome/", "Assetnote/", "PetalBot")
     agent = user_agents.parse(str(flask.request.user_agent))
     if (
         agent.is_bot

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.search",
-    version="1.2.6",
+    version="1.2.7",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical-web-and-design/canonicalwebteam.search",


### PR DESCRIPTION
## Done

Block more spammers https://logging.comms.canonical.com/search?width=1848&relative=86400&page=2&sortOrder=desc&q=service%3A%20ubuntu.com%20AND%20querystring%3A%20q%3D%2A%20AND%20httpstatus%3A%20200%20AND%20path%3A%20%22%2Fserver%2Fdocs%2Fsearch%22&rangetype=relative&fields=source%2Cmessage%2Cpath%2Cquerystring%2Creferrer%2Cuseragent&sortField=timestamp

## QA

Check that the following return 403

`curl -I -A "Mozilla/5.0 (Linux; Android 7.0;) AppleWebKit/537.36 (KHTML, like Gecko) Mobile Safari/537.36 (compatible; PetalBot;+https://webmaster.petalsearch.com/site/petalbot)" https://ubuntu-com-11845.demos.haus/search\?q\=application`

`curl -I -A "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.116 Safari/537.36 TheWorld 7" https://ubuntu-com-11845.demos.haus/search\?q\=application`
