### PR TITLE
Block search engine bots

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -45,7 +45,7 @@ jobs:
         pip3 install wheel
 
     - name: Test Python
-      run: python3 setup.py test
+      run: python3 -m unittest discover tests
 
   check-inclusive-naming:
     runs-on: ubuntu-latest

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,3 +10,4 @@ v1.2.4, 2022-07-09 -- Remove blocklist checks; move blocking logic to core searc
 v1.2.5, 2022-07-12 -- Block some more bot useragents
 v1.2.6, 2022-07-13 -- Block one more useragent - "gh"
 v1.2.7, 2022-07-15 -- Block more user agents - "Petalbot"
+v1.2.8, 2023-02-02 -- Block more bots - "Googlebot and bingbot"

--- a/canonicalwebteam/search/models.py
+++ b/canonicalwebteam/search/models.py
@@ -44,7 +44,13 @@ def get_search_results(
         "ALittle Client",
         "gh",
     )
-    bot_contains = ("HeadlessChrome/", "Assetnote/", "PetalBot")
+    bot_contains = (
+        "HeadlessChrome/",
+        "Assetnote/",
+        "PetalBot",
+        "Googlebot/",
+        "bingbot/",
+    )
     agent = user_agents.parse(str(flask.request.user_agent))
     if (
         agent.is_bot

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,10 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.search",
-    version="1.2.7",
+    version="1.2.8",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
-    url="https://github.com/canonical-web-and-design/canonicalwebteam.search",
+    url="https://github.com/canonical/canonicalwebteam.search",
     description=(
         "Flask extension to provide a search view for querying the webteam's "
         "Google Custom Search account"
@@ -16,5 +16,5 @@ setup(
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
     install_requires=["Flask>=1.0.2", "user-agents>=2.0.0"],
-    tests_require=["httpretty"],
+    tests_require=["httpretty", "Flask>=1.0.2", "user-agents>=2.0.0"],
 )


### PR DESCRIPTION



## QA

Follow this guide https://discourse.canonical.com/t/how-to-run-our-python-modules-for-local-development/308

Then 
```
curl -I -A "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/109.0.5414.101 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)" https://ubuntu-com-12492.demos.haus/search\?q\=application
```

