### PR TITLE
Search rate limits

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -45,7 +45,7 @@ jobs:
         pip3 install wheel
 
     - name: Test Python
-      run: python3 setup.py test
+      run: python3 -m unittest discover tests
 
   check-inclusive-naming:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install system dependencies
       run: |
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Install system dependencies
       run: |
@@ -37,15 +37,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-
-    - name: Install system dependencies
-      run: |
-        pip3 install --upgrade setuptools pip
-        pip3 install wheel
+    - uses: actions/checkout@v3
 
     - name: Test Python
-      run: python3 -m unittest discover tests
+      run: |
+        python3 setup.py install --user test
+
 
   check-inclusive-naming:
     runs-on: ubuntu-latest

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,4 +10,4 @@ v1.2.4, 2022-07-09 -- Remove blocklist checks; move blocking logic to core searc
 v1.2.5, 2022-07-12 -- Block some more bot useragents
 v1.2.6, 2022-07-13 -- Block one more useragent - "gh"
 v1.2.7, 2022-07-15 -- Block more user agents - "Petalbot"
-v1.2.8, 2023-02-02 -- Block more bots - "Googlebot and bingbot"
+v1.3.0, 2023-02-20 -- Add rate limits

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,3 +10,4 @@ v1.2.4, 2022-07-09 -- Remove blocklist checks; move blocking logic to core searc
 v1.2.5, 2022-07-12 -- Block some more bot useragents
 v1.2.6, 2022-07-13 -- Block one more useragent - "gh"
 v1.2.7, 2022-07-15 -- Block more user agents - "Petalbot"
+v1.2.8, 2023-02-02 -- Block more bots - "Googlebot and bingbot"

--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ app.add_url_rule(
     build_search_view(
         session=session,
         site="maas.io/docs",
-        template_path="docs/search.html"
-        search_engine_id="xxxxxxxxxx" # Optional argument, required by some of our sites
+        template_path="docs/search.html",
+        search_engine_id="xxxxxxxxxx", # Optional argument, required by some of our sites
+        request_limit="500/day", # Allows your to configure the limit at which the user will be forbidden to query more. Defaults to 500 per day
     )
 )
 ```

--- a/canonicalwebteam/search/models.py
+++ b/canonicalwebteam/search/models.py
@@ -44,7 +44,13 @@ def get_search_results(
         "ALittle Client",
         "gh",
     )
-    bot_contains = ("HeadlessChrome/", "Assetnote/", "PetalBot")
+    bot_contains = (
+        "HeadlessChrome/",
+        "Assetnote/",
+        "PetalBot",
+        "Googlebot/",
+        "bingbot/",
+    )
     agent = user_agents.parse(str(flask.request.user_agent))
     if (
         agent.is_bot

--- a/canonicalwebteam/search/models.py
+++ b/canonicalwebteam/search/models.py
@@ -48,8 +48,6 @@ def get_search_results(
         "HeadlessChrome/",
         "Assetnote/",
         "PetalBot",
-        "Googlebot/",
-        "bingbot/",
     )
     agent = user_agents.parse(str(flask.request.user_agent))
     if (

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.search",
-    version="1.2.8",
+    version="1.3.0",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.search",
@@ -15,6 +15,6 @@ setup(
     packages=find_packages(),
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
-    install_requires=["Flask>=1.0.2", "user-agents>=2.0.0"],
-    tests_require=["httpretty", "Flask>=1.0.2", "user-agents>=2.0.0"],
+    install_requires=["Flask>=1.0.2", "user-agents>=2.0.0", "limits>=3.2.0"],
+    tests_require=["httpretty"],
 )

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,10 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.search",
-    version="1.2.7",
+    version="1.2.8",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
-    url="https://github.com/canonical-web-and-design/canonicalwebteam.search",
+    url="https://github.com/canonical/canonicalwebteam.search",
     description=(
         "Flask extension to provide a search view for querying the webteam's "
         "Google Custom Search account"
@@ -16,5 +16,5 @@ setup(
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
     install_requires=["Flask>=1.0.2", "user-agents>=2.0.0"],
-    tests_require=["httpretty"],
+    tests_require=["httpretty", "Flask>=1.0.2", "user-agents>=2.0.0"],
 )

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -73,6 +73,18 @@ class TestApp(unittest.TestCase):
             ),
         )
 
+        # Rate limits
+        self.app.add_url_rule(
+            "/server/docs/limited/search",
+            "server-docs-search-limited",
+            build_search_view(
+                session=session,
+                template_path="docs/search.html",
+                site_restricted_search=True,
+                request_limit="0/second",
+            ),
+        )
+
         self.client = self.app.test_client()
 
     def tearDown(self):
@@ -246,3 +258,13 @@ class TestApp(unittest.TestCase):
             ),
             search_response.data,
         )
+
+    def test_rate_limit(self):
+        """
+        Test rate limits
+        """
+
+        search_response = self.client.get(
+            "/server/docs/limited/search?q=packer&start=20&num=3"
+        )
+        self.assertEqual(search_response.status_code, 429)


### PR DESCRIPTION
After doing some tests, I realised that doing a per minute limit will only block the request per minute (after 1 minute, it will allow it send requests again). So I will change it to maybe a per day basis e.g. 500/day, so that means after 500 requests it will ban that specific user for that endpoint for the rest of the day, which adheres to the quota on Google's side.

Writing a test also made me think that we should pass the rate limit as an argument, so that in different endpoints we can optionally change the limit.

## QA

Use https://github.com/canonical/ubuntu.com/pull/12514

Fixes https://warthogs.atlassian.net/browse/WD-1859?atlOrigin=eyJpIjoiMTYxMzI5NGRlODFjNGIxY2E5NWZiOGYzZmFlMjRiNGMiLCJwIjoiaiJ9