### PR TITLE
Remove rate limits dependency

### DIFF
--- a/.github/release-drafter.yaml
+++ b/.github/release-drafter.yaml
@@ -1,0 +1,8 @@
+change-template: "$TITLE (#$NUMBER)"
+exclude-labels:
+  - 'skip-changelog'
+template: |
+  ## Changes
+  $CHANGES
+  ## This release was made possible by the following contributors:
+  $CONTRIBUTORS

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ app.add_url_rule(
         site="maas.io/docs",
         template_path="docs/search.html",
         search_engine_id="xxxxxxxxxx", # Optional argument, required by some of our sites
-        request_limit="500/day", # Allows your to configure the limit at which the user will be forbidden to query more. Defaults to 500 per day
     )
 )
 ```

--- a/canonicalwebteam/search/views.py
+++ b/canonicalwebteam/search/views.py
@@ -6,10 +6,6 @@ import flask
 
 # Local
 from canonicalwebteam.search.models import get_search_results
-from limits import storage, strategies, parse
-
-memory_storage = storage.MemoryStorage()
-fixed_window = strategies.MovingWindowRateLimiter(memory_storage)
 
 
 class NoAPIKeyError(Exception):
@@ -22,7 +18,6 @@ def build_search_view(
     template_path="search.html",
     search_engine_id="009048213575199080868:i3zoqdwqk8o",
     site_restricted_search=False,
-    request_limit="500/day",
 ):
     """
     Build and return a view function that will query the
@@ -50,14 +45,6 @@ def build_search_view(
         """
         Get search results from Google Custom Search
         """
-        # Rate limit requests to protect from spamming
-        # To adjust this rate visit
-        # https://limits.readthedocs.io/en/latest/quickstart.html#examples
-        limit = parse(request_limit)
-        rate_limit = fixed_window.hit(limit)
-        if not rate_limit:
-            return flask.abort(429, f"The rate limit is: {request_limit}")
-
         # API key should always be provided as an environment variable
         search_api_key = os.getenv("SEARCH_API_KEY")
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="canonicalwebteam.search",
-    version="1.3.0",
+    version="2.0.0",
     author="Canonical webteam",
     author_email="webteam@canonical.com",
     url="https://github.com/canonical/canonicalwebteam.search",
@@ -15,6 +15,6 @@ setup(
     packages=find_packages(),
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
-    install_requires=["Flask>=1.0.2", "user-agents>=2.0.0", "limits>=3.2.0"],
+    install_requires=["Flask>=1.0.2", "user-agents>=2.0.0"],
     tests_require=["httpretty"],
 )

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -81,7 +81,6 @@ class TestApp(unittest.TestCase):
                 session=session,
                 template_path="docs/search.html",
                 site_restricted_search=True,
-                request_limit="0/second",
             ),
         )
 
@@ -258,13 +257,3 @@ class TestApp(unittest.TestCase):
             ),
             search_response.data,
         )
-
-    def test_rate_limit(self):
-        """
-        Test rate limits
-        """
-
-        search_response = self.client.get(
-            "/server/docs/limited/search?q=packer&start=20&num=3"
-        )
-        self.assertEqual(search_response.status_code, 429)


### PR DESCRIPTION
Remove rate limits as they are now handled by content-cache.

## QA

Use https://ubuntu-com-13283.demos.haus/ to test
Go to https://ubuntu-com-13283.demos.haus/server/docs search something and make sure it doesn't break.