### PR TITLE
Wd 12317 fix tests

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -41,7 +41,9 @@ jobs:
 
     - name: Test Python
       run: |
-        python3 setup.py install --user test
+        pip install -e .
+        pip install httpretty
+        python -m unittest discover tests
 
 
   check-inclusive-naming:


### PR DESCRIPTION
## Done
- Use `pip install` instead of `python3 setup.py` to install the package in tests, as using `setup.py` is deprecated. See https://github.com/pypa/setuptools/issues/917#issuecomment-1759240469