### PR TITLE
feat: Apply a more granular rate limit

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,3 +13,4 @@ v1.2.7, 2022-07-15 -- Block more user agents - "Petalbot"
 v1.3.0, 2023-02-20 -- Add rate limits
 v1.4.0, 2024-07-26 -- Migrate to Flask.Limiter for rate limits. Breaking Change: 'app' must be passed to 'build_search_view' as the positon 1 argument
 v2.0.0, 2024-08-02 -- Release 1.4.0 as major version change. Migrate to Flask.Limiter for rate limits. Breaking Change: 'app' must be passed to 'build_search_view' as the positon 1 argument
+v2.0.1, 2024-09-10 -- Adds a more granular rate limit: 2/second, 100/minute, 2000/day

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ app.add_url_rule(
         site="maas.io/docs",
         template_path="docs/search.html",
         search_engine_id="xxxxxxxxxx", # Optional argument, required by some of our sites
-        request_limit="500/day", # Allows your to configure the limit at which the user will be forbidden to query more. Defaults to 2000 per day
+        request_limit="500/day", # Allows your to configure the limit at which the user will be forbidden to query more. Defaults to 2/second, 100/minute, 2000/day
     )
 )
 ```

--- a/canonicalwebteam/search/views.py
+++ b/canonicalwebteam/search/views.py
@@ -24,7 +24,7 @@ def build_search_view(
     template_path="search.html",
     search_engine_id="009048213575199080868:i3zoqdwqk8o",
     site_restricted_search=False,
-    request_limit="2000/day;6/minute;1/second",
+    request_limit="2000/day;100/minute;2/second",
 ):
     """
     Build and return a view function that will query the

--- a/canonicalwebteam/search/views.py
+++ b/canonicalwebteam/search/views.py
@@ -24,7 +24,7 @@ def build_search_view(
     template_path="search.html",
     search_engine_id="009048213575199080868:i3zoqdwqk8o",
     site_restricted_search=False,
-    request_limit="2000/day",
+    request_limit="2/second;100/minute;2000/day",
 ):
     """
     Build and return a view function that will query the

--- a/canonicalwebteam/search/views.py
+++ b/canonicalwebteam/search/views.py
@@ -24,7 +24,7 @@ def build_search_view(
     template_path="search.html",
     search_engine_id="009048213575199080868:i3zoqdwqk8o",
     site_restricted_search=False,
-    request_limit="2/second;100/minute;2000/day",
+    request_limit="1/second;6/minute;2000/day",
 ):
     """
     Build and return a view function that will query the

--- a/canonicalwebteam/search/views.py
+++ b/canonicalwebteam/search/views.py
@@ -24,7 +24,7 @@ def build_search_view(
     template_path="search.html",
     search_engine_id="009048213575199080868:i3zoqdwqk8o",
     site_restricted_search=False,
-    request_limit="1/second;6/minute;2000/day",
+    request_limit="2000/day;6/minute;1/second",
 ):
     """
     Build and return a view function that will query the


### PR DESCRIPTION
## Done

- Apply a more granular default rate limit: 2/second, 100/minute, 2000/day

## QA

- Check out [the demo](https://ubuntu-com-14284.demos.haus/)
- Use the search to test the rate limits, Rate limits are currently set at 2000/day, 6/minute, 1/second for testing purposes. (pretty hard to test the seconds one, I am aware)

## TODO

- before merging set rate limits to 2000/day;100/minute;2/second. This is the rate limit we want applied on our live site. This is to prevent spamming, you can read more on it here: https://flask-limiter.readthedocs.io/en/stable/strategies.html#fixed-window

## Fixes

Issue: https://warthogs.atlassian.net/browse/WD-14706